### PR TITLE
fix: Take into account Unbreaking enchantment in tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.beanfeed</groupId>
     <artifactId>TreeChopper</artifactId>
-    <version>1.0</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>TreeChopper</name>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.4-R0.1-SNAPSHOT</version>
+            <version>1.21.7-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/beanfeed/treechopper/listeners/BlockBreakEvent.java
+++ b/src/main/java/com/beanfeed/treechopper/listeners/BlockBreakEvent.java
@@ -7,6 +7,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -123,7 +124,19 @@ public class BlockBreakEvent implements Listener {
                         Damageable dmg = (Damageable) meta;
 
                         if (dmg != null && dmg.getDamage() <= toolDurability) {
-                            dmg.setDamage(dmg.getDamage() + 1);
+                            if (meta.hasEnchant(Enchantment.UNBREAKING)) {
+                                int unbLevel = meta.getEnchantLevel(Enchantment.UNBREAKING);
+                                int chanceOfDmg = 1/(unbLevel+1);
+
+                                // Unbreaking 1 = 50% chance of taking damage
+                                // Unbreaking 2 = 33% chance of taking damage
+                                // Unbreaking 3 = 25% chance of taking damage
+                                if (rand.nextDouble() >= chanceOfDmg) {
+                                    dmg.setDamage(dmg.getDamage() + 1);
+                                }
+                            } else {
+                                dmg.setDamage(dmg.getDamage() + 1);
+                            }
 
                             tool.setItemMeta(dmg);
 

--- a/src/main/java/com/beanfeed/treechopper/listeners/BlockBreakEvent.java
+++ b/src/main/java/com/beanfeed/treechopper/listeners/BlockBreakEvent.java
@@ -126,12 +126,12 @@ public class BlockBreakEvent implements Listener {
                         if (dmg != null && dmg.getDamage() <= toolDurability) {
                             if (meta.hasEnchant(Enchantment.UNBREAKING)) {
                                 int unbLevel = meta.getEnchantLevel(Enchantment.UNBREAKING);
-                                int chanceOfDmg = 1/(unbLevel+1);
+                                double chanceOfDmg = (double) 1 /(unbLevel+1);
 
                                 // Unbreaking 1 = 50% chance of taking damage
                                 // Unbreaking 2 = 33% chance of taking damage
                                 // Unbreaking 3 = 25% chance of taking damage
-                                if (rand.nextDouble() >= chanceOfDmg) {
+                                if (rand.nextDouble() < chanceOfDmg) {
                                     dmg.setDamage(dmg.getDamage() + 1);
                                 }
                             } else {


### PR DESCRIPTION
This PR allows the plug-in to take Unbreaking into consideration when breaking nearby blocks.

A pretty obvious note: `breakNaturally` only handles other type of enchantments, related to the loot of the block. (this is also reinforced by the fact that the original maintainer manually sets the damage)